### PR TITLE
Add TrollStore integration

### DIFF
--- a/Antrag/AppDelegate.swift
+++ b/Antrag/AppDelegate.swift
@@ -12,13 +12,21 @@ import IDeviceSwift
 class AppDelegate: UIResponder, UIApplicationDelegate {
 	let heartbeart = HeartbeatManager.shared
 	
-	func application(
-		_ application: UIApplication,
-		didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-	) -> Bool {
-		_createSourcesDirectory()
-		return true
-	}
+        func application(
+                _ application: UIApplication,
+                didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+        ) -> Bool {
+                _createSourcesDirectory()
+                if !TrollStoreHelper.isInstalled {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                UIAlertController.showAlertWithOk(
+                                        title: "TrollStore Required",
+                                        message: "Please install this app through TrollStore."
+                                )
+                        }
+                }
+                return true
+        }
 	
 	private func _createSourcesDirectory() {
 		let fileManager = FileManager.default

--- a/Antrag/Resources/Info.plist
+++ b/Antrag/Resources/Info.plist
@@ -2,22 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
+        <key>UIApplicationSceneManifest</key>
+        <dict>
+                <key>UIApplicationSupportsMultipleScenes</key>
+                <false/>
+                <key>UISceneConfigurations</key>
+                <dict>
+                        <key>UIWindowSceneSessionRoleApplication</key>
+                        <array>
+                                <dict>
+                                        <key>UISceneConfigurationName</key>
+                                        <string>Default Configuration</string>
+                                        <key>UISceneDelegateClassName</key>
+                                        <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+                                </dict>
+                        </array>
+                </dict>
+        </dict>
+        <key>LSApplicationQueriesSchemes</key>
+        <array>
+                <string>trollstore</string>
+        </array>
 </dict>
 </plist>

--- a/Antrag/Utilities/TrollStoreHelper.swift
+++ b/Antrag/Utilities/TrollStoreHelper.swift
@@ -1,0 +1,24 @@
+import Foundation
+import UIKit
+
+enum TrollStoreHelper {
+    static var isInstalled: Bool {
+        // Check typical TrollStore directories or environment variables
+        if FileManager.default.fileExists(atPath: "/var/mobile/Library/TrollStore") {
+            return true
+        }
+        if ProcessInfo.processInfo.environment["TROLLSTORE"] != nil {
+            return true
+        }
+        // TrollStore apps are usually installed inside this directory
+        if Bundle.main.bundlePath.contains("TrollStore") {
+            return true
+        }
+        return false
+    }
+
+    static func openTrollStore() {
+        guard let url = URL(string: "trollstore://") else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/Antrag/Views/Settings/ATSettingsView.swift
+++ b/Antrag/Views/Settings/ATSettingsView.swift
@@ -41,15 +41,26 @@ struct ATSettingsView: View {
 					}
 				}
 				
-				Section(.localized("Pairing")) {
-					NavigationLink(.localized("Tunnel & Pairing")) {
-						ATTunnelView()
-					}
-				}
-				
-				_feedback()
-				_help()
-			}
+                                Section(.localized("Pairing")) {
+                                        NavigationLink(.localized("Tunnel & Pairing")) {
+                                                ATTunnelView()
+                                        }
+                                }
+
+                                if TrollStoreHelper.isInstalled {
+                                        Section("TrollStore") {
+                                                Button(
+                                                        .localized("Open TrollStore"),
+                                                        systemImage: "t.square"
+                                                ) {
+                                                        TrollStoreHelper.openTrollStore()
+                                                }
+                                        }
+                                }
+
+                                _feedback()
+                                _help()
+                        }
 			.navigationTitle(.localized("Settings"))
 			.navigationBarTitleDisplayMode(.large)
 		}


### PR DESCRIPTION
## Summary
- add TrollStoreHelper to check installation and open TrollStore
- show an alert if the app is not installed via TrollStore
- allow launching TrollStore from settings when available
- add URL scheme for TrollStore queries

## Testing
- `make` *(fails: `xcodebuild` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1a008c048329bdca38ee6101e129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "TrollStore" section in the settings with a button to open TrollStore, visible if TrollStore is installed.
  * The app now checks for TrollStore at launch and alerts users if it is not installed, prompting installation through TrollStore.

* **Bug Fixes**
  * Improved handling of TrollStore detection and user notification.

* **Chores**
  * Updated app permissions to allow querying the TrollStore URL scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->