### PR TITLE
Switch to TrollStore

### DIFF
--- a/Antrag/AppDelegate.swift
+++ b/Antrag/AppDelegate.swift
@@ -8,17 +8,28 @@
 import UIKit
 import IDeviceSwift
 
+// TrollStore integration
+import Foundation
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 	let heartbeart = HeartbeatManager.shared
 	
-	func application(
-		_ application: UIApplication,
-		didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-	) -> Bool {
-		_createSourcesDirectory()
-		return true
-	}
+        func application(
+                _ application: UIApplication,
+                didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+        ) -> Bool {
+                _createSourcesDirectory()
+
+                // Verify TrollStore installation
+                if !Bundle.main.isInstalledViaTrollStore {
+                        UIAlertController.showAlertWithOk(
+                                title: "TrollStore Required",
+                                message: "This app must be installed via TrollStore to function correctly."
+                        )
+                }
+                return true
+        }
 	
 	private func _createSourcesDirectory() {
 		let fileManager = FileManager.default

--- a/Antrag/Extensions/Bundle+TrollStore.swift
+++ b/Antrag/Extensions/Bundle+TrollStore.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Bundle {
+    var isInstalledViaTrollStore: Bool {
+        let containerURL = URL(fileURLWithPath: bundlePath).deletingLastPathComponent()
+        let fm = FileManager.default
+        let trollMarker = containerURL.appendingPathComponent("_TrollStore").path
+        let liteMarker = containerURL.appendingPathComponent("_TrollStoreLite").path
+        return fm.fileExists(atPath: trollMarker) || fm.fileExists(atPath: liteMarker)
+    }
+}

--- a/Antrag/InstallationAppProxy.swift
+++ b/Antrag/InstallationAppProxy.swift
@@ -1,0 +1,54 @@
+import UIKit
+
+protocol InstallationProxyAppsDelegate: AnyObject {
+    func updateApplications(with apps: [AppInfo])
+}
+
+class InstallationAppProxy {
+    weak var delegate: InstallationProxyAppsDelegate?
+    private let troll = TrollStoreManager.shared
+
+    func listApps() async throws {
+        let apps = troll.installedApps()
+        await MainActor.run {
+            delegate?.updateApplications(with: apps)
+        }
+    }
+
+    static func deleteApp(for id: String) async throws {
+        TrollStoreManager.shared.uninstall(appId: id)
+    }
+
+    private static var iconCache: [String: UIImage] = [:]
+    private static let iconCacheQueue = DispatchQueue(label: "iconCacheQueue")
+
+    static func getAppIconCached(for id: String) async throws -> UIImage? {
+        if let cached = iconCacheQueue.sync(execute: { iconCache[id] }) {
+            return cached
+        }
+        let image = try await getAppIcon(for: id)
+        if let img = image {
+            iconCacheQueue.async { iconCache[id] = img }
+        }
+        return image
+    }
+
+    static func getAppIcon(for id: String) async throws -> UIImage? {
+        let apps = TrollStoreManager.shared.installedApps()
+        guard let app = apps.first(where: { $0.CFBundleIdentifier == id }),
+              let path = app.Path else { return nil }
+
+        let icons = app.CFBundleIcons?["CFBundlePrimaryIcon"]?.value as? [String: Any]
+        let iconFiles = icons?["CFBundleIconFiles"] as? [String] ?? []
+        for file in iconFiles.reversed() {
+            let full = URL(fileURLWithPath: path).appendingPathComponent(file).path
+            if let image = UIImage(contentsOfFile: full) {
+                return image
+            }
+            if let image = UIImage(contentsOfFile: full + "@2x.png") {
+                return image
+            }
+        }
+        return nil
+    }
+}

--- a/Antrag/Supporting Files/Antrag-Bridging-Header.h
+++ b/Antrag/Supporting Files/Antrag-Bridging-Header.h
@@ -1,3 +1,4 @@
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
+#import "../TrollStore/TSApplicationsManager.h"

--- a/Antrag/TrollStoreManager.swift
+++ b/Antrag/TrollStoreManager.swift
@@ -1,0 +1,30 @@
+import Foundation
+import UIKit
+
+@objc class TrollStoreManager: NSObject {
+    static let shared = TrollStoreManager()
+    private let applicationsPath = "/var/containers/Bundle/TrollStore/Applications"
+
+    func installedApps() -> [IDeviceSwift.AppInfo] {
+        var apps: [IDeviceSwift.AppInfo] = []
+        guard let contents = try? FileManager.default.contentsOfDirectory(atPath: applicationsPath) else { return [] }
+        for item in contents where item.hasSuffix(".app") {
+            let appPath = (applicationsPath as NSString).appendingPathComponent(item)
+            let infoPath = (appPath as NSString).appendingPathComponent("Info.plist")
+            if let data = FileManager.default.contents(atPath: infoPath),
+               let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] {
+                let info = IDeviceSwift.AppInfo(dictionary: plist)
+                apps.append(info)
+            }
+        }
+        return apps
+    }
+
+    func uninstall(appId: String) {
+        _ = TSApplicationsManager.shared()?.uninstallApp(appId)
+    }
+
+    func open(appId: String) {
+        _ = TSApplicationsManager.shared()?.openApplication(withBundleID: appId)
+    }
+}

--- a/IDeviceSwift/AnyCodable.swift
+++ b/IDeviceSwift/AnyCodable.swift
@@ -1,0 +1,65 @@
+//
+//  AnyCodable.swift
+//  Feather
+//
+//  Created by samara on 27.04.2025.
+//
+
+import Foundation
+
+public struct AnyCodable: Codable {
+	public let value: Any
+	
+	public init(_ value: Any) {
+		self.value = value
+	}
+	
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		
+		if container.decodeNil() {
+			self.value = NSNull()
+		} else if let bool = try? container.decode(Bool.self) {
+			self.value = bool
+		} else if let int = try? container.decode(Int.self) {
+			self.value = int
+		} else if let uint = try? container.decode(UInt.self) {
+			self.value = uint
+		} else if let double = try? container.decode(Double.self) {
+			self.value = double
+		} else if let string = try? container.decode(String.self) {
+			self.value = string
+		} else if let array = try? container.decode([AnyCodable].self) {
+			self.value = array.map { $0.value }
+		} else if let dictionary = try? container.decode([String: AnyCodable].self) {
+			self.value = dictionary.mapValues { $0.value }
+		} else {
+			throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable cannot decode value")
+		}
+	}
+	
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.singleValueContainer()
+		
+		switch self.value {
+		case is NSNull:
+			try container.encodeNil()
+		case let bool as Bool:
+			try container.encode(bool)
+		case let int as Int:
+			try container.encode(int)
+		case let uint as UInt:
+			try container.encode(uint)
+		case let double as Double:
+			try container.encode(double)
+		case let string as String:
+			try container.encode(string)
+		case let array as [Any]:
+			try container.encode(array.map { AnyCodable($0) })
+		case let dictionary as [String: Any]:
+			try container.encode(dictionary.mapValues { AnyCodable($0) })
+		default:
+			throw EncodingError.invalidValue(self.value, EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyCodable cannot encode value"))
+		}
+	}
+}

--- a/IDeviceSwift/AppInfo.swift
+++ b/IDeviceSwift/AppInfo.swift
@@ -1,0 +1,64 @@
+//
+//  AppInfo.swift
+//  Antrag
+//
+//  Created by samara on 7.06.2025.
+//
+
+import Foundation
+
+public struct AppInfo: Codable, Identifiable {
+	public var id: String { CFBundleIdentifier ?? UUID().uuidString }
+	
+	public let CFBundleName: String?
+	public let UISupportedInterfaceOrientations: [String]?
+	public let DTXcodeBuild: String?
+	public let LSRequiresIPhoneOS: Bool?
+	public let UIStatusBarStyle: String?
+	public let Entitlements: [String: AnyCodable]?
+	public let ITSAppUsesNonExemptEncryption: AnyCodable?
+	public let DTPlatformVersion: String?
+	public let CFBundleURLTypes: [[String: AnyCodable]]?
+	public let DTSDKBuild: String?
+	public let EnvironmentVariables: [String: String]?
+	public let UISupportedDevices: [String]?
+	public let IsAppClip: Bool?
+	public let CFBundleNumericVersion: Int?
+	public let CFBundleInfoDictionaryVersion: String?
+	public let SequenceNumber: Int?
+	public let CFBundleDisplayName: String?
+	public let CFBundleExecutable: String?
+	public let ApplicationType: String?
+	public let UIApplicationSupportsIndirectInputEvents: Bool?
+	public let CFBundleIcons_iPad: [String: AnyCodable]? // Note: keys with ~ipad must be adjusted
+	public let IsHostBackupEligible: Bool?
+	public let IsDemotedApp: Bool?
+	public let DTPlatformName: String?
+	public let CFBundleDevelopmentRegion: String?
+	public let UISupportsDocumentBrowser: Bool?
+	public let SignerIdentity: String?
+	public let UISupportedInterfaceOrientations_iPad: [String]?
+	public let UIRequiredDeviceCapabilities: [String]?
+	public let LSSupportsOpeningDocumentsInPlace: Bool?
+	public let DTSDKName: String?
+	public let DTAppStoreToolsBuild: String?
+	public let Container: String?
+	public let MinimumOSVersion: String?
+	public let IsUpgradeable: Bool?
+	public let ApplicationDSID: Int?
+	public let UIFileSharingEnabled: Bool?
+	public let DTCompiler: String?
+	public let DTPlatformBuild: String?
+	public let CFBundleIdentifier: String?
+	public let Path: String?
+	public let CFBundleVersion: String?
+	public let CFBundleShortVersionString: String?
+	public let CFBundleSupportedPlatforms: [String]?
+	public let CFBundleIcons: [String: AnyCodable]?
+	public let UILaunchScreen: AnyCodable?
+	public let BuildMachineOSBuild: String?
+	public let UIApplicationSceneManifest: [String: AnyCodable]?
+	public let CFBundlePackageType: String?
+	public let UIDeviceFamily: [Int]?
+	public let DTXcode: String?
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/khcrysalis/antrag?include_prereleases)](https://github.com/khcrysalis/protokolle/releases)
 [![GitHub License](https://img.shields.io/github/license/khcrysalis/antrag?color=%23C96FAD)](https://github.com/khcrysalis/protokolle/blob/main/LICENSE)
 
-An app to list iOS/iPadOS app's, for stock devices. This app uses [idevice](https://github.com/jkcoxson/idevice) and lockdownd pairing to retrieve installed apps.
+An app to list iOS/iPadOS apps. This version relies on [TrollStore](https://github.com/opa334/TrollStore) to access installed apps directly on device.
 
 ### Features
 
@@ -16,12 +16,10 @@ Visit [releases](https://github.com/khcrysalis/Antrag/releases) and get the late
 
 ## How does it work?
 
-- Establish a heartbeat with a TCP provider (the app will need this for later).
-  - For it to be successful, we need a pairing file from [JitterbugPair](https://github.com/osy/Jitterbug/releases) and a [VPN](https://apps.apple.com/us/app/stosvpn/id6744003051).
-- When preparing the list, we need to establish another connection but for `installation_proxy` using our heartbeat provider and client handle.
-- Then we can use `installation_proxy_get_apps` using that handle to list applications.
+- Establish a heartbeat with a TCP provider for compatibility with older setups.
+- When installed through TrollStore, the app reads the application list directly from the device's TrollStore container without needing pairing files.
 
-Due to how it works right now we need both a VPN and a lockdownd pairing file, this means you will need a computer for its initial setup.
+This version does not require external pairing files. Instead, make sure the app is installed through TrollStore to enable local management of applications.
 
 ## Building
 
@@ -59,7 +57,7 @@ Using the makefile will automatically create an adhoc ipa inside the packages di
 ## Acknowledgements
 
 - [Samara](https://github.com/khcrysalis) - The maker
-- [idevice](https://github.com/jkcoxson/idevice) - Backend functionality, uses `installation_proxy` to retrieve messages.
+- [TrollStore](https://github.com/opa334/TrollStore) - Provides access to installed apps and installation management.
 
 ## License 
 

--- a/TrollStore/TSApplicationsManager.h
+++ b/TrollStore/TSApplicationsManager.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+#define TROLLSTORE_ROOT_PATH @"/var/containers/Bundle/TrollStore"
+#define TROLLSTORE_MAIN_PATH [TROLLSTORE_ROOT_PATH stringByAppendingPathComponent:@"Main"]
+#define TROLLSTORE_APPLICATIONS_PATH [TROLLSTORE_ROOT_PATH stringByAppendingPathComponent:@"Applications"]
+
+@interface TSApplicationsManager : NSObject
+
++ (instancetype)sharedInstance;
+
+- (NSArray*)installedAppPaths;
+
+- (NSError*)errorForCode:(int)code;
+- (int)installIpa:(NSString*)pathToIpa force:(BOOL)force log:(NSString**)logOut;
+- (int)installIpa:(NSString*)pathToIpa;
+- (int)uninstallApp:(NSString*)appId;
+- (int)uninstallAppByPath:(NSString*)path;
+- (BOOL)openApplicationWithBundleID:(NSString *)appID;
+- (int)enableJITForBundleID:(NSString *)appID;
+- (int)changeAppRegistration:(NSString*)appPath toState:(NSString*)newState;
+
+@end

--- a/TrollStore/TSApplicationsManager.m
+++ b/TrollStore/TSApplicationsManager.m
@@ -1,0 +1,196 @@
+#import "TSApplicationsManager.h"
+#import <TSUtil.h>
+extern NSUserDefaults* trollStoreUserDefaults();
+
+@implementation TSApplicationsManager
+
++ (instancetype)sharedInstance
+{
+    static TSApplicationsManager *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[TSApplicationsManager alloc] init];
+    });
+    return sharedInstance;
+}
+
+- (NSArray*)installedAppPaths
+{
+    return trollStoreInstalledAppBundlePaths();
+}
+
+- (NSError*)errorForCode:(int)code
+{
+    NSString* errorDescription = @"Unknown Error";
+    switch(code)
+    {
+        // IPA install errors
+        case 166:
+        errorDescription = @"The IPA file does not exist or is not accessible.";
+        break;
+        case 167:
+        errorDescription = @"The IPA file does not appear to contain an app.";
+        break;
+        case 168:
+        errorDescription = @"Failed to extract IPA file.";
+        break;
+        case 169:
+        errorDescription = @"Failed to extract update tar file.";
+        break;
+        // App install errors
+        case 170:
+        errorDescription = @"Failed to create container for app bundle.";
+        break;
+        case 171:
+        errorDescription = @"A non "APP_NAME@" or a "OTHER_APP_NAME@" app with the same identifier is already installed. If you are absolutely sure it is not, you can force install it.";
+        break;
+        case 172:
+        errorDescription = @"The app does not contain an Info.plist file.";
+        break;
+        case 173:
+        errorDescription = @"The app is not signed with a fake CoreTrust certificate and ldid is not installed. Install ldid in the settings tab and try again.";
+        break;
+        case 174:
+        errorDescription = @"The app's main executable does not exist.";
+        break;
+        case 175: {
+            //if (@available(iOS 16, *)) {
+            //    errorDescription = @"Failed to sign the app.";
+            //}
+            //else {
+                errorDescription = @"Failed to sign the app. ldid returned a non zero status code.";
+            //}
+        }
+        break;
+        case 176:
+        errorDescription = @"The app's Info.plist is missing required values.";
+        break;
+        case 177:
+        errorDescription = @"Failed to mark app as TrollStore app.";
+        break;
+        case 178:
+        errorDescription = @"Failed to copy app bundle.";
+        break;
+        case 179:
+        errorDescription = @"The app you tried to install has the same identifier as a system app already installed on the device. The installation has been prevented to protect you from possible bootloops or other issues.";
+        break;
+        case 180:
+        errorDescription = @"The app you tried to install has an encrypted main binary, which cannot have the CoreTrust bypass applied to it. Please ensure you install decrypted apps.";
+        break;
+        case 181:
+        errorDescription = @"Failed to add app to icon cache.";
+        break;
+        case 182:
+        errorDescription = @"The app was installed successfully, but requires developer mode to be enabled to run. After rebooting, select \"Turn On\" to enable developer mode.";
+        break;
+        case 183:
+        errorDescription = @"Failed to enable developer mode.";
+        break;
+        case 184:
+        errorDescription = @"The app was installed successfully, but has additional binaries that are encrypted (e.g. extensions, plugins). The app itself should work, but you may experience broken functionality as a result.";
+        break;
+        case 185:
+        errorDescription = @"Failed to sign the app. The CoreTrust bypass returned a non zero status code.";
+    }
+
+    NSError* error = [NSError errorWithDomain:TrollStoreErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : errorDescription}];
+    return error;
+}
+
+- (int)installIpa:(NSString*)pathToIpa force:(BOOL)force log:(NSString**)logOut
+{
+    NSMutableArray* args = [NSMutableArray new];
+    [args addObject:@"install"];
+    if(force)
+    {
+        [args addObject:@"force"];
+    }
+    NSNumber* installationMethodToUseNum = [trollStoreUserDefaults() objectForKey:@"installationMethod"];
+    int installationMethodToUse = installationMethodToUseNum ? installationMethodToUseNum.intValue : 1;
+    if(installationMethodToUse == 1)
+    {
+        [args addObject:@"custom"];
+    }
+    else
+    {
+        [args addObject:@"installd"];
+    }
+    [args addObject:pathToIpa];
+
+    int ret = spawnRoot(rootHelperPath(), args, nil, logOut);
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApplicationsChanged" object:nil];
+    return ret;
+}
+
+- (int)installIpa:(NSString*)pathToIpa
+{
+    return [self installIpa:pathToIpa force:NO log:nil];
+}
+
+- (int)uninstallApp:(NSString*)appId
+{
+    if(!appId) return -200;
+
+    NSMutableArray* args = [NSMutableArray new];
+    [args addObject:@"uninstall"];
+
+    NSNumber* uninstallationMethodToUseNum = [trollStoreUserDefaults() objectForKey:@"uninstallationMethod"];
+    int uninstallationMethodToUse = uninstallationMethodToUseNum ? uninstallationMethodToUseNum.intValue : 0;
+    if(uninstallationMethodToUse == 1)
+    {
+        [args addObject:@"custom"];
+    }
+    else
+    {
+        [args addObject:@"installd"];
+    }
+
+    [args addObject:appId];
+
+    int ret = spawnRoot(rootHelperPath(), args, nil, nil);
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApplicationsChanged" object:nil];
+    return ret;
+}
+
+- (int)uninstallAppByPath:(NSString*)path
+{
+    if(!path) return -200;
+
+    NSMutableArray* args = [NSMutableArray new];
+    [args addObject:@"uninstall-path"];
+
+    NSNumber* uninstallationMethodToUseNum = [trollStoreUserDefaults() objectForKey:@"uninstallationMethod"];
+    int uninstallationMethodToUse = uninstallationMethodToUseNum ? uninstallationMethodToUseNum.intValue : 0;
+    if(uninstallationMethodToUse == 1)
+    {
+        [args addObject:@"custom"];
+    }
+    else
+    {
+        [args addObject:@"installd"];
+    }
+
+    [args addObject:path];
+
+    int ret = spawnRoot(rootHelperPath(), args, nil, nil);
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApplicationsChanged" object:nil];
+    return ret;
+}
+
+- (BOOL)openApplicationWithBundleID:(NSString *)appId
+{
+    return [[LSApplicationWorkspace defaultWorkspace] openApplicationWithBundleID:appId];
+}
+
+- (int)enableJITForBundleID:(NSString *)appId
+{
+    return spawnRoot(rootHelperPath(), @[@"enable-jit", appId], nil, nil);
+}
+
+- (int)changeAppRegistration:(NSString*)appPath toState:(NSString*)newState
+{
+    if(!appPath || !newState) return -200;
+    return spawnRoot(rootHelperPath(), @[@"modify-registration", appPath, newState], nil, nil);
+}
+
+@end


### PR DESCRIPTION
## Summary
- replace idevice-based workflow with TrollStore
- check whether the app was installed via TrollStore
- link TrollStore headers via bridging header
- document TrollStore usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f1fe4e84483299cbe5cf5ef990e93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Detects if the app is installed via TrollStore and alerts if not.
  - Displays locally installed apps with icons, leveraging caching for faster loads.
  - Allows uninstalling and launching installed apps directly from the app.

- Performance
  - Added icon caching to reduce repeated loading and improve responsiveness.

- Documentation
  - Updated README to reflect TrollStore-based installation and simplified setup (no external pairing files required).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->